### PR TITLE
Enhance installation and cleanup processes(#29)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -34,6 +34,14 @@
             </intent-filter>
         </activity>
 
+        <receiver
+            android:name=".ui.util.InstallResultReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="${applicationId}.INSTALL_STATUS" />
+            </intent-filter>
+        </receiver>
+
         <service
             android:name=".manager.ModuleService"
             android:exported="true" />

--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:name=".LSPApplication"
@@ -44,6 +45,16 @@
             android:exported="true"
             android:multiprocess="false"
             android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/manager/src/main/java/org/lsposed/lspatch/LSPApplication.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/LSPApplication.kt
@@ -18,7 +18,7 @@ class LSPApplication : Application() {
 
     lateinit var prefs: SharedPreferences
     lateinit var tmpApkDir: File
-    lateinit var targetApkFile: File
+    var targetApkFiles: ArrayList<File>? = null
 
     val globalScope = CoroutineScope(Dispatchers.Default)
 

--- a/manager/src/main/java/org/lsposed/lspatch/LSPApplication.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/LSPApplication.kt
@@ -18,6 +18,7 @@ class LSPApplication : Application() {
 
     lateinit var prefs: SharedPreferences
     lateinit var tmpApkDir: File
+    lateinit var targetApkFile: File
 
     val globalScope = CoroutineScope(Dispatchers.Default)
 

--- a/manager/src/main/java/org/lsposed/lspatch/Patcher.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/Patcher.kt
@@ -65,7 +65,6 @@ object Patcher {
                     val apkFile = File(lspApp.externalCacheDir, apk.name)
                     apk.copyTo(apkFile, overwrite = true)
                     apkFileList.add(apkFile)
-//                    Log.d("lspatch", "Patched file: ${apk.name} -> ${apkFile.absolutePath}")
                     output.use {
                         apk.inputStream().use { input ->
                             input.copyTo(output)

--- a/manager/src/main/java/org/lsposed/lspatch/Patcher.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/Patcher.kt
@@ -10,8 +10,8 @@ import org.lsposed.lspatch.share.Constants
 import org.lsposed.lspatch.share.PatchConfig
 import org.lsposed.patch.LSPatch
 import org.lsposed.patch.util.Logger
+import java.io.File
 import java.io.IOException
-import java.util.Collections.addAll
 
 object Patcher {
 
@@ -59,6 +59,9 @@ object Patcher {
                         ?: throw IOException("Failed to create output file")
                     val output = lspApp.contentResolver.openOutputStream(file.uri)
                         ?: throw IOException("Failed to open output stream")
+                    val apkFile = File(lspApp.externalCacheDir, apk.name)
+                    apk.copyTo(apkFile, overwrite = true)
+                    lspApp.targetApkFile = apkFile
                     output.use {
                         apk.inputStream().use { input ->
                             input.copyTo(output)

--- a/manager/src/main/java/org/lsposed/lspatch/ui/activity/MainActivity.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/ui/activity/MainActivity.kt
@@ -1,5 +1,8 @@
 package org.lsposed.lspatch.ui.activity
 
+import android.annotation.SuppressLint
+import android.content.IntentFilter
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -8,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -21,13 +25,22 @@ import org.lsposed.lspatch.ui.page.appCurrentDestinationAsState
 import org.lsposed.lspatch.ui.page.destinations.Destination
 import org.lsposed.lspatch.ui.page.startAppDestination
 import org.lsposed.lspatch.ui.theme.LSPTheme
+import org.lsposed.lspatch.ui.util.InstallResultReceiver
 import org.lsposed.lspatch.ui.util.LocalSnackbarHost
 
 class MainActivity : ComponentActivity() {
 
+    private val splitInstallReceiver by lazy { InstallResultReceiver() }
+
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
     @OptIn(ExperimentalAnimationApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(splitInstallReceiver, IntentFilter(InstallResultReceiver.ACTION_INSTALL_STATUS), RECEIVER_NOT_EXPORTED)
+        } else {
+            registerReceiver(splitInstallReceiver, IntentFilter(InstallResultReceiver.ACTION_INSTALL_STATUS))
+        }
         setContent {
             val navController = rememberAnimatedNavController()
             LSPTheme {
@@ -46,6 +59,11 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        unregisterReceiver(splitInstallReceiver)
     }
 }
 

--- a/manager/src/main/java/org/lsposed/lspatch/ui/page/NewPatchScreen.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/ui/page/NewPatchScreen.kt
@@ -79,27 +79,22 @@ fun NewPatchScreen(
     val viewModel = viewModel<NewPatchViewModel>()
     val snackbarHost = LocalSnackbarHost.current
     val errorUnknown = stringResource(R.string.error_unknown)
-    val storageLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { apks ->
-            if (apks.isEmpty()) {
-                navigator.navigateUp()
-                return@rememberLauncherForActivityResult
-            }
-            runBlocking {
-                LSPPackageManager.getAppInfoFromApks(apks)
-                    .onSuccess {
-                        viewModel.dispatch(ViewAction.ConfigurePatch(it.first()))
-                    }
-                    .onFailure {
-                        lspApp.globalScope.launch {
-                            snackbarHost.showSnackbar(
-                                it.message ?: errorUnknown
-                            )
-                        }
-                        navigator.navigateUp()
-                    }
-            }
+    val storageLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { apks ->
+        if (apks.isEmpty()) {
+            navigator.navigateUp()
+            return@rememberLauncherForActivityResult
         }
+        runBlocking {
+            LSPPackageManager.getAppInfoFromApks(apks)
+                .onSuccess {
+                    viewModel.dispatch(ViewAction.ConfigurePatch(it.first()))
+                }
+                .onFailure {
+                    lspApp.globalScope.launch { snackbarHost.showSnackbar(it.message ?: errorUnknown) }
+                    navigator.navigateUp()
+                }
+        }
+    }
 
     var showSelectModuleDialog by remember { mutableStateOf(false) }
     val noXposedModules = stringResource(R.string.patch_no_xposed_module)
@@ -164,7 +159,6 @@ fun NewPatchScreen(
                 }
             }
         }
-
         PatchState.SELECTING -> {
             resultRecipient.onNavResult {
                 Log.d(TAG, "onNavResult: $it")
@@ -177,7 +171,6 @@ fun NewPatchScreen(
                 }
             }
         }
-
         else -> {
             Scaffold(
                 topBar = {
@@ -186,7 +179,6 @@ fun NewPatchScreen(
                         PatchState.PATCHING,
                         PatchState.FINISHED,
                         PatchState.ERROR -> CenterAlignedTopAppBar(title = { Text(viewModel.patchApp.app.packageName) })
-
                         else -> Unit
                     }
                 },
@@ -212,12 +204,10 @@ fun NewPatchScreen(
             }
 
             if (showSelectModuleDialog) {
-                AlertDialog(
-                    onDismissRequest = { showSelectModuleDialog = false },
+                AlertDialog(onDismissRequest = { showSelectModuleDialog = false },
                     confirmButton = {},
                     dismissButton = {
-                        TextButton(
-                            content = { Text(stringResource(android.R.string.cancel)) },
+                        TextButton(content = { Text(stringResource(android.R.string.cancel)) },
                             onClick = { showSelectModuleDialog = false })
                     },
                     title = {
@@ -229,8 +219,7 @@ fun NewPatchScreen(
                     },
                     text = {
                         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                            TextButton(
-                                modifier = Modifier.fillMaxWidth(),
+                            TextButton(modifier = Modifier.fillMaxWidth(),
                                 colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.secondary),
                                 onClick = {
                                     storageModuleLauncher.launch(arrayOf("application/vnd.android.package-archive"))
@@ -242,13 +231,11 @@ fun NewPatchScreen(
                                     style = MaterialTheme.typography.bodyLarge
                                 )
                             }
-                            TextButton(
-                                modifier = Modifier.fillMaxWidth(),
+                            TextButton(modifier = Modifier.fillMaxWidth(),
                                 colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.secondary),
                                 onClick = {
                                     navigator.navigate(
-                                        SelectAppsScreenDestination(
-                                            true,
+                                        SelectAppsScreenDestination(true,
                                             viewModel.embeddedModules.mapTo(ArrayList()) { it.app.packageName })
                                     )
                                     showSelectModuleDialog = false
@@ -337,12 +324,7 @@ private fun PatchOptionsBody(modifier: Modifier, onAddEmbed: () -> Unit) {
                 extraContent = {
                     TextButton(
                         onClick = onAddEmbed,
-                        content = {
-                            Text(
-                                text = stringResource(R.string.patch_embed_modules),
-                                style = MaterialTheme.typography.bodyLarge
-                            )
-                        }
+                        content = { Text(text = stringResource(R.string.patch_embed_modules), style = MaterialTheme.typography.bodyLarge) }
                     )
                 }
             )
@@ -356,9 +338,7 @@ private fun PatchOptionsBody(modifier: Modifier, onAddEmbed: () -> Unit) {
             title = stringResource(R.string.patch_debuggable)
         )
         SettingsCheckBox(
-            modifier = Modifier.clickable {
-                viewModel.overrideVersionCode = !viewModel.overrideVersionCode
-            },
+            modifier = Modifier.clickable { viewModel.overrideVersionCode = !viewModel.overrideVersionCode },
             checked = viewModel.overrideVersionCode,
             icon = Icons.Outlined.Layers,
             title = stringResource(R.string.patch_override_version_code),
@@ -390,9 +370,7 @@ private fun PatchOptionsBody(modifier: Modifier, onAddEmbed: () -> Unit) {
                 DropdownMenuItem(
                     text = {
                         Row(verticalAlignment = Alignment.CenterVertically) {
-                            RadioButton(
-                                selected = viewModel.sigBypassLevel == it,
-                                onClick = { viewModel.sigBypassLevel = it })
+                            RadioButton(selected = viewModel.sigBypassLevel == it, onClick = { viewModel.sigBypassLevel = it })
                             Text(sigBypassLvStr(it))
                         }
                     },
@@ -444,10 +422,7 @@ private fun DoPatchBody(modifier: Modifier, navigator: DestinationsNavigator) {
                             when (it.first) {
                                 Log.DEBUG -> Text(text = it.second)
                                 Log.INFO -> Text(text = it.second)
-                                Log.ERROR -> Text(
-                                    text = it.second,
-                                    color = MaterialTheme.colorScheme.error
-                                )
+                                Log.ERROR -> Text(text = it.second, color = MaterialTheme.colorScheme.error)
                             }
                         }
                     }
@@ -472,26 +447,18 @@ private fun DoPatchBody(modifier: Modifier, navigator: DestinationsNavigator) {
                         scope.launch {
                             installing = 0
                             if (status == PackageInstaller.STATUS_SUCCESS) {
-                                lspApp.globalScope.launch {
-                                    snackbarHost.showSnackbar(
-                                        installSuccessfully
-                                    )
-                                }
+                                lspApp.globalScope.launch { snackbarHost.showSnackbar(installSuccessfully) }
                                 navigator.navigateUp()
                             } else if (status != LSPPackageManager.STATUS_USER_CANCELLED) {
                                 val result = snackbarHost.showSnackbar(installFailed, copyError)
                                 if (result == SnackbarResult.ActionPerformed) {
-                                    val cm =
-                                        lspApp.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                                    val cm = lspApp.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                                     cm.setPrimaryClip(ClipData.newPlainText("LSPatch", message))
                                 }
                             }
                         }
                     }
-                    if (installing == 1) InstallDialog(
-                        viewModel.patchApp,
-                        onFinish
-                    ) else if (installing == 2) InstallDialog2(viewModel.patchApp, onFinish)
+                    if (installing == 1) InstallDialog(viewModel.patchApp, onFinish) else if (installing == 2) InstallDialog2(viewModel.patchApp, onFinish)
                     Row(Modifier.padding(top = 12.dp)) {
                         Button(
                             modifier = Modifier.weight(1f),
@@ -512,7 +479,6 @@ private fun DoPatchBody(modifier: Modifier, navigator: DestinationsNavigator) {
                         )
                     }
                 }
-
                 PatchState.ERROR -> {
                     Row(Modifier.padding(top = 12.dp)) {
                         Button(
@@ -524,19 +490,13 @@ private fun DoPatchBody(modifier: Modifier, navigator: DestinationsNavigator) {
                         Button(
                             modifier = Modifier.weight(1f),
                             onClick = {
-                                val cm =
-                                    lspApp.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                                cm.setPrimaryClip(
-                                    ClipData.newPlainText(
-                                        "LSPatch",
-                                        viewModel.logs.joinToString { it.second + "\n" })
-                                )
+                                val cm = lspApp.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                                cm.setPrimaryClip(ClipData.newPlainText("LSPatch", viewModel.logs.joinToString { it.second + "\n" }))
                             },
                             content = { Text(stringResource(R.string.copy_error)) }
                         )
                     }
                 }
-
                 else -> Unit
             }
         }
@@ -546,13 +506,7 @@ private fun DoPatchBody(modifier: Modifier, navigator: DestinationsNavigator) {
 @Composable
 private fun InstallDialog(patchApp: AppInfo, onFinish: (Int, String?) -> Unit) {
     val scope = rememberCoroutineScope()
-    var uninstallFirst by remember {
-        mutableStateOf(
-            ShizukuApi.isPackageInstalledWithoutPatch(
-                patchApp.app.packageName
-            )
-        )
-    }
+    var uninstallFirst by remember { mutableStateOf(ShizukuApi.isPackageInstalledWithoutPatch(patchApp.app.packageName)) }
     var installing by remember { mutableStateOf(0) }
     suspend fun doInstall() {
         Log.i(TAG, "Installing app ${patchApp.app.packageName}")
@@ -571,12 +525,7 @@ private fun InstallDialog(patchApp: AppInfo, onFinish: (Int, String?) -> Unit) {
 
     if (uninstallFirst) {
         AlertDialog(
-            onDismissRequest = {
-                onFinish(
-                    LSPPackageManager.STATUS_USER_CANCELLED,
-                    "User cancelled"
-                )
-            },
+            onDismissRequest = { onFinish(LSPPackageManager.STATUS_USER_CANCELLED, "User cancelled") },
             confirmButton = {
                 TextButton(
                     onClick = {
@@ -599,12 +548,7 @@ private fun InstallDialog(patchApp: AppInfo, onFinish: (Int, String?) -> Unit) {
             },
             dismissButton = {
                 TextButton(
-                    onClick = {
-                        onFinish(
-                            LSPPackageManager.STATUS_USER_CANCELLED,
-                            "User cancelled"
-                        )
-                    },
+                    onClick = { onFinish(LSPPackageManager.STATUS_USER_CANCELLED, "User cancelled") },
                     content = { Text(stringResource(android.R.string.cancel)) }
                 )
             },
@@ -648,10 +592,8 @@ private fun InstallDialog2(patchApp: AppInfo, onFinish: (Int, String?) -> Unit) 
     }
 
     fun doInstall() {
-        Log.i(TAG, "Installing app ${patchApp.app.packageName}")
         val apkFiles = lspApp.targetApkFiles
         if (apkFiles.isNullOrEmpty()){
-            Log.e(TAG, "No target APK files found for installation")
             onFinish(LSPPackageManager.STATUS_USER_CANCELLED, "No target APK files found for installation")
             return
         }

--- a/manager/src/main/java/org/lsposed/lspatch/ui/page/manage/AppManagePage.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/ui/page/manage/AppManagePage.kt
@@ -192,11 +192,7 @@ fun AppManageBody(
                             onClick = {
                                 expanded = false
                                 scope.launch {
-                                    if (!ShizukuApi.isPermissionGranted) {
-                                        snackbarHost.showSnackbar(shizukuUnavailable)
-                                    } else {
-                                        viewModel.dispatch(AppManageViewModel.ViewAction.UpdateLoader(it.first, it.second))
-                                    }
+                                    viewModel.dispatch(AppManageViewModel.ViewAction.UpdateLoader(it.first, it.second))
                                 }
                             }
                         )

--- a/manager/src/main/java/org/lsposed/lspatch/ui/util/Utils.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/ui/util/Utils.kt
@@ -1,13 +1,23 @@
 package org.lsposed.lspatch.ui.util
 
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageInstaller
 import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
 import android.util.Log
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.lsposed.lspatch.BuildConfig
 import java.io.File
+import java.io.IOException
 
 val LazyListState.lastVisibleItemIndex
     get() = layoutInfo.visibleItemsInfo.lastOrNull()?.index
@@ -57,4 +67,122 @@ fun uninstallApkByPackageName(context: Context, packageName: String) = try {
     context.startActivity(intent)
 } catch (e: Exception) {
     Log.e("LSPatch", "uninstallApkByPackageName", e)
+}
+
+class InstallResultReceiver : BroadcastReceiver() {
+
+    companion object {
+        const val ACTION_INSTALL_STATUS = "${BuildConfig.APPLICATION_ID}.INSTALL_STATUS"
+
+        fun createPendingIntent(context: Context, sessionId: Int): PendingIntent {
+            val intent = Intent(context, InstallResultReceiver::class.java).apply {
+                action = ACTION_INSTALL_STATUS
+            }
+            val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+            return PendingIntent.getBroadcast(context, sessionId, intent, flags)
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_INSTALL_STATUS) {
+            return
+        }
+
+        val status =
+            intent.getIntExtra(PackageInstaller.EXTRA_STATUS, PackageInstaller.STATUS_FAILURE)
+        val message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+
+        when (status) {
+            PackageInstaller.STATUS_PENDING_USER_ACTION -> {
+                val confirmIntent = intent.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
+                if (confirmIntent != null) {
+                    context.startActivity(confirmIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+                }
+                Log.d("lspatch", "请求用户确认安装")
+            }
+
+            PackageInstaller.STATUS_SUCCESS -> {
+                // 安装成功
+                Log.d("lspatch", "安装完成")
+            }
+
+            else -> {
+                // 安装失败
+                Log.e("lspatch", "安装失败: $status, $message")
+            }
+        }
+    }
+}
+
+/**
+ * 安装分包 APK
+ * @param context 上下文
+ * @param apkFiles APK 文件列表 (包括 base.apk 和 split aab 的 apk)
+ * @return 安装是否成功提交（注意：这不代表最终安装成功，只代表安装请求已发出）
+ */
+
+suspend fun installApks(context: Context, apkFiles: List<File>): Boolean {
+    // 检查权限：应用是否被允许安装未知来源应用
+    if (!context.packageManager.canRequestPackageInstalls()) {
+        Log.e("lspatch", "没有安装未知来源应用的权限")
+        // 引导用户去设置页面开启权限
+        val intent = Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+            data = "package:${context.packageName}".toUri()
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        context.startActivity(intent)
+        return false
+    }
+
+    // 检查文件是否存在
+    apkFiles.forEach {
+        if (!it.exists()) {
+            Log.e("lspatch", "APK 文件不存在: ${it.absolutePath}")
+            return false
+        }
+    }
+
+    return withContext(Dispatchers.IO) {
+        val packageInstaller = context.packageManager.packageInstaller
+        var session: PackageInstaller.Session? = null
+        try {
+            // 1. 创建安装会话
+            val params =
+                PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+            val sessionId = packageInstaller.createSession(params)
+            session = packageInstaller.openSession(sessionId)
+
+            // 2. 循环将所有 APK 文件写入会话
+            apkFiles.forEach { apkFile ->
+                Log.d("lspatch", "正在添加 APK 到会话: ${apkFile.name}")
+                session.openWrite(apkFile.name, 0, apkFile.length()).use { outputStream ->
+                    apkFile.inputStream().use { inputStream ->
+                        inputStream.copyTo(outputStream)
+                        session.fsync(outputStream)
+                    }
+                }
+            }
+
+            // 3. 创建 PendingIntent 用于接收安装结果
+            val pendingIntent = InstallResultReceiver.createPendingIntent(context, sessionId)
+
+            // 4. 提交会话，开始安装
+            session.commit(pendingIntent.intentSender)
+            Log.d("lspatch", "安装会话已提交，等待用户确认...")
+            true
+        } catch (e: IOException) {
+            Log.e("lspatch", "安装失败 (IO异常)", e)
+            // 如果发生错误，放弃会话
+            session?.abandon()
+            false
+        } catch (e: Exception) {
+            Log.e("lspatch", "安装失败 (未知异常)", e)
+            session?.abandon()
+            false
+        }
+    }
 }

--- a/manager/src/main/java/org/lsposed/lspatch/ui/util/Utils.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/ui/util/Utils.kt
@@ -1,6 +1,13 @@
 package org.lsposed.lspatch.ui.util
 
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.util.Log
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.core.content.FileProvider
+import androidx.core.net.toUri
+import java.io.File
 
 val LazyListState.lastVisibleItemIndex
     get() = layoutInfo.visibleItemsInfo.lastOrNull()?.index
@@ -10,3 +17,44 @@ val LazyListState.lastItemIndex
 
 val LazyListState.isScrolledToEnd
     get() = lastVisibleItemIndex == lastItemIndex
+
+fun checkIsApkFixedByLSP(context: Context, packageName: String): Boolean {
+    return try {
+        val app =
+            context.packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+        (app.metaData?.containsKey("lspatch") != true)
+    } catch (_: PackageManager.NameNotFoundException) {
+        Log.e("LSPatch", "Package not found: $packageName")
+        false
+    } catch (e: Exception) {
+        Log.e("LSPatch", "Unexpected error in checkIsApkFixedByLSP", e)
+        false
+    }
+}
+
+fun installApk(context: Context, apkFile: File) {
+    try {
+        val apkUri =
+            FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", apkFile)
+
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            addCategory("android.intent.category.DEFAULT")
+            setDataAndType(apkUri, "application/vnd.android.package-archive")
+        }
+        context.startActivity(intent)
+    } catch (e: Exception) {
+        Log.e("LSPatch", "installApk", e)
+    }
+}
+
+fun uninstallApkByPackageName(context: Context, packageName: String) = try {
+    val intent = Intent(Intent.ACTION_DELETE).apply {
+        data = "package:$packageName".toUri()
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(intent)
+} catch (e: Exception) {
+    Log.e("LSPatch", "uninstallApkByPackageName", e)
+}

--- a/manager/src/main/java/org/lsposed/lspatch/ui/viewmodel/manage/AppManageViewModel.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/ui/viewmodel/manage/AppManageViewModel.kt
@@ -18,6 +18,7 @@ import org.lsposed.lspatch.lspApp
 import org.lsposed.lspatch.share.Constants
 import org.lsposed.lspatch.share.PatchConfig
 import org.lsposed.lspatch.ui.util.installApk
+import org.lsposed.lspatch.ui.util.installApks
 import org.lsposed.lspatch.ui.viewstate.ProcessingState
 import org.lsposed.lspatch.util.LSPPackageManager
 import org.lsposed.lspatch.util.LSPPackageManager.AppInfo
@@ -123,7 +124,16 @@ class AppManageViewModel : ViewModel() {
                 }
                 Patcher.patch(logger, Patcher.Options(false, config, patchPaths, embeddedModulePaths))
                 if (!ShizukuApi.isPermissionGranted) {
-                    installApk(lspApp, lspApp.targetApkFile)
+                    val apkFiles = lspApp.targetApkFiles
+                    if (apkFiles.isNullOrEmpty()){
+                        Log.e(TAG, "No patched APK files found")
+                        throw RuntimeException("No patched APK files found")
+                    }
+                    if (apkFiles.size > 1) {
+                        val success = installApks(lspApp, apkFiles)
+                    } else  {
+                        installApk(lspApp, apkFiles.first())
+                    }
                 } else {
                     val (status, message) = LSPPackageManager.install()
                     if (status != PackageInstaller.STATUS_SUCCESS) throw RuntimeException(message)

--- a/manager/src/main/java/org/lsposed/lspatch/ui/viewmodel/manage/AppManageViewModel.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/ui/viewmodel/manage/AppManageViewModel.kt
@@ -17,6 +17,7 @@ import org.lsposed.lspatch.Patcher
 import org.lsposed.lspatch.lspApp
 import org.lsposed.lspatch.share.Constants
 import org.lsposed.lspatch.share.PatchConfig
+import org.lsposed.lspatch.ui.util.installApk
 import org.lsposed.lspatch.ui.viewstate.ProcessingState
 import org.lsposed.lspatch.util.LSPPackageManager
 import org.lsposed.lspatch.util.LSPPackageManager.AppInfo
@@ -86,7 +87,10 @@ class AppManageViewModel : ViewModel() {
         updateLoaderState = ProcessingState.Processing
         val result = runCatching {
             withContext(Dispatchers.IO) {
-                LSPPackageManager.cleanTmpApkDir()
+                LSPPackageManager.apply {
+                    cleanTmpApkDir()
+                    cleanExternalTmpApkDir()
+                }
                 val apkPaths = listOf(appInfo.app.sourceDir) + (appInfo.app.splitSourceDirs ?: emptyArray())
                 val patchPaths = mutableListOf<String>()
                 val embeddedModulePaths = mutableListOf<String>()
@@ -118,8 +122,12 @@ class AppManageViewModel : ViewModel() {
                     }
                 }
                 Patcher.patch(logger, Patcher.Options(false, config, patchPaths, embeddedModulePaths))
-                val (status, message) = LSPPackageManager.install()
-                if (status != PackageInstaller.STATUS_SUCCESS) throw RuntimeException(message)
+                if (!ShizukuApi.isPermissionGranted) {
+                    installApk(lspApp, lspApp.targetApkFile)
+                } else {
+                    val (status, message) = LSPPackageManager.install()
+                    if (status != PackageInstaller.STATUS_SUCCESS) throw RuntimeException(message)
+                }
             }
         }
         updateLoaderState = ProcessingState.Done(result)

--- a/manager/src/main/java/org/lsposed/lspatch/util/LSPPackageManager.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/util/LSPPackageManager.kt
@@ -79,6 +79,12 @@ object LSPPackageManager {
         }
     }
 
+    suspend fun cleanExternalTmpApkDir(){
+        withContext(Dispatchers.IO) {
+            lspApp.externalCacheDir?.listFiles()?.forEach(File::delete)
+        }
+    }
+
     suspend fun install(): Pair<Int, String?> {
         Log.i(TAG, "Perform install patched apks")
         var status = PackageInstaller.STATUS_FAILURE

--- a/manager/src/main/res/xml/file_paths.xml
+++ b/manager/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="external_files" path="." />
+    <files-path name="files" path="." />
+</paths>

--- a/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
+++ b/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
@@ -1,36 +1,30 @@
 package org.lsposed.lspatch.metaloader;
 
 import android.annotation.SuppressLint;
-import android.app.AppComponentFactory;
 import android.app.ActivityThread;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.IPackageManager;
-import android.os.Build;
-import android.os.Process;
-import android.os.ServiceManager;
-import android.util.JsonReader;
+import android.app.AppComponentFactory;
 import android.util.Log;
 
-import org.lsposed.hiddenapibypass.HiddenApiBypass;
 import org.lsposed.lspatch.share.Constants;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.zip.ZipFile;
 
 @SuppressLint("UnsafeDynamicallyLoadedCode")
 public class LSPAppComponentFactoryStub extends AppComponentFactory {
 
     private static final String TAG = "LSPatch-MetaLoader";
-    private static final Map<String, String> archToLib = new HashMap<String, String>(4);
+    private static final Map<String, String> archToLib = Map.of(
+            "arm", "armeabi-v7a",
+            "arm64", "arm64-v8a",
+            "x86", "x86",
+            "x86_64", "x86_64"
+    );
 
     public static byte[] dex;
 
@@ -45,11 +39,6 @@ public class LSPAppComponentFactoryStub extends AppComponentFactory {
 
     private static void bootstrap() {
         try {
-            archToLib.put("arm", "armeabi-v7a");
-            archToLib.put("arm64", "arm64-v8a");
-            archToLib.put("x86", "x86");
-            archToLib.put("x86_64", "x86_64");
-
             var cl = Objects.requireNonNull(LSPAppComponentFactoryStub.class.getClassLoader());
             Class<?> VMRuntime = Class.forName("dalvik.system.VMRuntime");
             Method getRuntime = VMRuntime.getDeclaredMethod("getRuntime");
@@ -59,51 +48,17 @@ public class LSPAppComponentFactoryStub extends AppComponentFactory {
             String arch = (String) vmInstructionSet.invoke(getRuntime.invoke(null));
             String libName = archToLib.get(arch);
 
-            boolean useManager = false;
-            String soPath;
-
-            try (var is = cl.getResourceAsStream(Constants.CONFIG_ASSET_PATH);
-                 var reader = new JsonReader(new InputStreamReader(is))) {
-                reader.beginObject();
-                while (reader.hasNext()) {
-                    var name = reader.nextName();
-                    if (name.equals("useManager")) {
-                        useManager = reader.nextBoolean();
-                        break;
-                    } else {
-                        reader.skipValue();
-                    }
-                }
+            Log.i(TAG, "Bootstrap loader from embedment");
+            try (var is = cl.getResourceAsStream(Constants.LOADER_DEX_ASSET_PATH);
+                 var os = new ByteArrayOutputStream()) {
+                transfer(is, os);
+                dex = os.toByteArray();
             }
-
-            if (useManager) {
-                Log.i(TAG, "Bootstrap loader from manager");
-                var ipm = IPackageManager.Stub.asInterface(ServiceManager.getService("package"));
-                ApplicationInfo manager;
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    manager = (ApplicationInfo) HiddenApiBypass.invoke(IPackageManager.class, ipm, "getApplicationInfo", Constants.MANAGER_PACKAGE_NAME, 0L, Process.myUid() / 100000);
-                } else {
-                    manager = ipm.getApplicationInfo(Constants.MANAGER_PACKAGE_NAME, 0, Process.myUid() / 100000);
-                }
-                try (var zip = new ZipFile(new File(manager.sourceDir));
-                     var is = zip.getInputStream(zip.getEntry(Constants.LOADER_DEX_ASSET_PATH));
-                     var os = new ByteArrayOutputStream()) {
-                    transfer(is, os);
-                    dex = os.toByteArray();
-                }
-                soPath = manager.sourceDir + "!/assets/lspatch/so/" + libName + "/liblspatch.so";
-            } else {
-                Log.i(TAG, "Bootstrap loader from embedment");
-                try (var is = cl.getResourceAsStream(Constants.LOADER_DEX_ASSET_PATH);
-                     var os = new ByteArrayOutputStream()) {
-                    transfer(is, os);
-                    dex = os.toByteArray();
-                }
-                soPath = cl.getResource("assets/lspatch/so/" + libName + "/liblspatch.so").getPath().substring(5);
-            }
+            String soPath = cl.getResource("assets/lspatch/so/" + libName + "/liblspatch.so").getPath().substring(5);
 
             System.load(soPath);
         } catch (Throwable e) {
+            Log.e(TAG, "Error when loading liblspatch.so", e);
             throw new ExceptionInInitializerError(e);
         }
     }

--- a/patch-loader/src/main/java/org/lsposed/lspatch/service/FixedLocalApplicationService.java
+++ b/patch-loader/src/main/java/org/lsposed/lspatch/service/FixedLocalApplicationService.java
@@ -1,0 +1,121 @@
+package org.lsposed.lspatch.service;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Environment;
+import android.os.IBinder;
+import android.os.ParcelFileDescriptor;
+import android.os.RemoteException;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.lsposed.lspatch.util.ModuleLoader;
+import org.lsposed.lspd.models.Module;
+import org.lsposed.lspd.service.ILSPApplicationService;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class FixedLocalApplicationService extends ILSPApplicationService.Stub {
+
+    private static final String TAG = "LSPatch";
+    private static final String PREFS_NAME = "lspatch";
+    private static final String KEY_MODULES = "modules";
+
+    private final List<Module> modules = new ArrayList<>();
+
+    public FixedLocalApplicationService(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        String moduleString = prefs.getString(KEY_MODULES, "[]");
+        Log.i(TAG, "Using fixed local application service. Modules data: " + moduleString);
+
+        try {
+            JSONArray modulesArray = new JSONArray(moduleString);
+            PackageManager pm = context.getPackageManager();
+            for (int i = 0; i < modulesArray.length(); i++) {
+                JSONObject moduleObject = modulesArray.getJSONObject(i);
+                String packageName = moduleObject.getString("packageName");
+                String apkPath = moduleObject.getString("apkPath");
+                File apkFile = new File(apkPath);
+
+                if (!apkFile.exists()) {
+                    Log.w(TAG, "Module APK not found at cached path: " + apkPath + " for package: " + packageName);
+                    try {
+                        ApplicationInfo info = pm.getApplicationInfo(packageName, 0);
+                        apkPath = info.sourceDir;
+                        apkFile = new File(apkPath);
+                        if (apkFile.exists()) {
+                            Log.i(TAG, "Found module APK via PackageManager: " + apkPath);
+                        } else {
+                            Log.e(TAG, "Module APK still not found via PackageManager for: " + packageName);
+                            continue; // Skip this module if APK is not found
+                        }
+                    } catch (PackageManager.NameNotFoundException e) {
+                        Log.e(TAG, "Module package not found: " + packageName, e);
+                        continue; // Skip this module
+                    }
+                }
+
+                Module module = new Module();
+                module.apkPath = apkPath;
+                module.packageName = packageName;
+                try {
+                    module.file = ModuleLoader.loadModule(apkPath);
+                    if (module.file != null) {
+                        modules.add(module);
+                        Log.i(TAG, "Successfully loaded module: " + packageName + " from " + apkPath);
+                    } else {
+                        Log.e(TAG, "Failed to load module file for: " + packageName);
+                    }
+                } catch (Exception loadException) {
+                    Log.e(TAG, "Error loading module file for: " + packageName + " from " + apkPath, loadException);
+                }
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "Error parsing modules JSON", e);
+        } catch (Exception e) { // Catch unexpected errors during initialization
+            Log.e(TAG, "Unexpected error initializing FixedLocalApplicationService", e);
+        }
+    }
+
+    @Override
+    public boolean isLogMuted() throws RemoteException {
+        // Consider making this configurable if needed
+        return false;
+    }
+
+    @Override
+    public List<Module> getLegacyModulesList() {
+        // Return an immutable list or a copy to prevent external modification
+        return Collections.unmodifiableList(modules);
+    }
+
+    @Override
+    public List<Module> getModulesList() {
+        // Currently returns an empty list, behavior maintained
+        return new ArrayList<>();
+    }
+
+    @Override
+    public String getPrefsPath(String packageName) {
+        // Consider validating packageName or handling potential exceptions
+        return new File(Environment.getDataDirectory(), "data/" + packageName + "/shared_prefs/").getAbsolutePath();
+    }
+
+    @Override
+    public ParcelFileDescriptor requestInjectedManagerBinder(List<IBinder> binder) {
+        // Currently returns null, behavior maintained
+        return null;
+    }
+
+    @Override
+    public IBinder asBinder() {
+        return this;
+    }
+}

--- a/patch-loader/src/main/java/org/lsposed/lspatch/service/RemoteApplicationService.java
+++ b/patch-loader/src/main/java/org/lsposed/lspatch/service/RemoteApplicationService.java
@@ -76,7 +76,7 @@ public class RemoteApplicationService implements ILSPApplicationService {
             if (!success) throw new TimeoutException("Bind service timeout");
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException |
                  InterruptedException | TimeoutException e) {
-            Toast.makeText(context, "Unable to connect to Manager", Toast.LENGTH_SHORT).show();
+//            Toast.makeText(context, "Unable to connect to Manager", Toast.LENGTH_SHORT).show();
             var r = new RemoteException("Failed to get manager binder");
             r.initCause(e);
             throw r;

--- a/patch/src/main/java/org/lsposed/patch/LSPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/LSPatch.java
@@ -283,29 +283,29 @@ public class LSPatch {
             }
 
             if (!useManager) {
-                logger.i("Adding loader dex...");
-                try (var is = getClass().getClassLoader().getResourceAsStream(LOADER_DEX_ASSET_PATH)) {
-                    dstZFile.add(LOADER_DEX_ASSET_PATH, is);
-                } catch (Throwable e) {
-                    throw new PatchError("Error when adding assets", e);
-                }
-
-                logger.i("Adding native lib...");
-                // copy so and dex files into the unzipped apk
-                // do not put liblspatch.so into apk!lib because x86 native bridge causes crash
-                for (String arch : ARCHES) {
-                    String entryName = "assets/lspatch/so/" + arch + "/liblspatch.so";
-                    try (var is = getClass().getClassLoader().getResourceAsStream(entryName)) {
-                        dstZFile.add(entryName, is, false); // no compress for so
-                    } catch (Throwable e) {
-                        // More exception info
-                        throw new PatchError("Error when adding native lib", e);
-                    }
-                    logger.d("added " + entryName);
-                }
-
                 logger.i("Embedding modules...");
                 embedModules(dstZFile);
+            }
+
+            logger.i("Adding loader dex...");
+            try (var is = getClass().getClassLoader().getResourceAsStream(LOADER_DEX_ASSET_PATH)) {
+                dstZFile.add(LOADER_DEX_ASSET_PATH, is);
+            } catch (Throwable e) {
+                throw new PatchError("Error when adding assets", e);
+            }
+
+            logger.i("Adding native lib...");
+            // copy so and dex files into the unzipped apk
+            // do not put liblspatch.so into apk!lib because x86 native bridge causes crash
+            for (String arch : ARCHES) {
+                String entryName = "assets/lspatch/so/" + arch + "/liblspatch.so";
+                try (var is = getClass().getClassLoader().getResourceAsStream(entryName)) {
+                    dstZFile.add(entryName, is, false); // no compress for so
+                } catch (Throwable e) {
+                    // More exception info
+                    throw new PatchError("Error when adding native lib", e);
+                }
+                logger.d("added " + entryName);
             }
 
             // create zip link


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and stability of the `LSPatch` application. The most important changes include modifications to the AndroidManifest.xml file, updates to the `LSPApplication` and `Patcher` classes, and enhancements to the `NewPatchScreen` and `AppManagePage` user interfaces.

### Permissions and Providers:

* Added the `REQUEST_INSTALL_PACKAGES` permission to the `AndroidManifest.xml` file.
* Added a `FileProvider` to the `AndroidManifest.xml` to support file sharing.

### Application and Patching Logic:

* Introduced a new `targetApkFile` property in `LSPApplication` to handle APK files.
* Updated the `Patcher` class to copy the APK to the external cache directory and assign it to `targetApkFile`.

### User Interface Enhancements:

* Modified `NewPatchScreen` to include a new `InstallDialog2` for handling APK installations with additional uninstall logic.
* Added functions to `Utils.kt` to check if an APK is fixed by LSP, install APKs, and uninstall APKs by package name.

### Clean-Up and Utility Functions:

* Added a method to clean the external temporary APK directory in `LSPPackageManager`.
* Created a new XML file `file_paths.xml` to define paths for file sharing.