### PR TITLE
Fixed the crash issue of the injection loader on some Android.

### DIFF
--- a/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
+++ b/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
@@ -99,7 +99,23 @@ public class LSPAppComponentFactoryStub extends AppComponentFactory {
                     transfer(is, os);
                     dex = os.toByteArray();
                 }
-                soPath = cl.getResource("assets/lspatch/so/" + libName + "/liblspatch.so").getPath().substring(5);
+                java.net.URL url = cl.getResource("assets/npatch/so/" + libName + "/libnpatch.so");
+                if (url == null) {
+                    throw new RuntimeException("Should not happen: libnpatch.so not found in assets");
+                }
+                String rawPath = url.getPath();
+                if (rawPath.startsWith("file:")) {
+                    soPath = rawPath.substring(5);
+                } else if (rawPath.startsWith("jar:file:")) {
+                    soPath = rawPath.substring(9);
+                } else {
+                    soPath = rawPath;
+                }
+                try {
+                    soPath = java.net.URLDecoder.decode(soPath, "UTF-8");
+                } catch (java.io.UnsupportedEncodingException e) {
+                }
+                Log.i(TAG, "Loading native lib from: " + soPath);
             }
 
             System.load(soPath);


### PR DESCRIPTION
Corrected path resolution logic:

On some Android 16 devices, getResource may return a path starting with jar:file:.

Added detection and processing for the prefix "jar:file:", to avoid path errors caused by direct string truncation.

Added URLDecoder to support paths containing special characters.

AppZygote detection:

Check with ActivityThread.currentActivityThread() to determine if the current process is an appZygote, and if so, skip loading to avoid errors.