### PR TITLE
Improve compatibility of native library path resolution

### DIFF
--- a/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
+++ b/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
@@ -99,7 +99,10 @@ public class LSPAppComponentFactoryStub extends AppComponentFactory {
                     transfer(is, os);
                     dex = os.toByteArray();
                 }
-                soPath = cl.getResource("assets/lspatch/so/" + libName + "/liblspatch.so").getPath().substring(5);
+                String resourcePath = cl.getResource("assets/lspatch/so/" + libName + "/liblspatch.so").getPath();
+                Log.d(TAG, "Resource path: " + resourcePath);
+                String[] pathParts = resourcePath.split("file:");
+                soPath = pathParts[pathParts.length - 1];
             }
 
             System.load(soPath);


### PR DESCRIPTION
Replaced rigid substring extraction with a dynamic split by "file:" to handle varying URI schemes (e.g., `file:` vs `jar:file:`) across different devices.