### PR TITLE
Adding the ability to add a key com.google.android.geo.API_KEY to the manifest 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Note: debug builds are only available in Github Actions
 1. Follow the instructions of the manager app
 
 + Adding a meta-data field with the com.google.android.geo.API_KEY parameter
-To be able to add a _meta-data_ field to the _AndroidManifest.xml_ file with the com.google.android.geo.API_KEY parameter and its correct value, you must specify it in the _share/java/src/main/java/org/lsposed/lspatch/share/Constants.java_ file before compiling LSPatch.
-After that, in the manager you can use the item "Set GeoAPIKey", and in lspatch.jar - the parameter "-g" or "--geoapi".
+1. To be able to add a _meta-data_ field to the _AndroidManifest.xml_ file with the com.google.android.geo.API_KEY parameter and its correct value, you must specify it in the _share/java/src/main/java/org/lsposed/lspatch/share/Constants.java_ file before compiling LSPatch.
+1. After that, in the manager you can use the item "Set GeoAPIKey", and in lspatch.jar - the parameter "-g" or "--geoapi".
   
 
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Note: debug builds are only available in Github Actions
 1. Download and install `manager.apk` on an Android device
 1. Follow the instructions of the manager app
 
++ Adding a meta-data field with the com.google.android.geo.API_KEY parameter
+To be able to add a _meta-data_ field to the _AndroidManifest.xml_ file with the com.google.android.geo.API_KEY parameter and its correct value, you must specify it in the _share/java/src/main/java/org/lsposed/lspatch/share/Constants.java_ file before compiling LSPatch.
+After that, in the manager you can use the item "Set GeoAPIKey", and in lspatch.jar - the parameter "-g" or "--geoapi".
+  
+
+
 ## Translation Contributing
 
 You can contribute translation [here](https://crowdin.com/project/lspatch_jingmatrix).

--- a/manager/src/main/java/org/lsposed/lspatch/Patcher.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/Patcher.kt
@@ -29,6 +29,7 @@ object Patcher {
                 add("-l"); add(config.sigBypassLevel.toString())
                 if (config.useManager) add("--manager")
                 if (config.overrideVersionCode) add("-r")
+                if (config.setGeoAPIKey) add("-g")
                 if (Configs.detailPatchLogs) add("-v")
                 embeddedModules?.forEach {
                     add("-m"); add(it)

--- a/manager/src/main/java/org/lsposed/lspatch/ui/page/NewPatchScreen.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/ui/page/NewPatchScreen.kt
@@ -331,6 +331,13 @@ private fun PatchOptionsBody(modifier: Modifier, onAddEmbed: () -> Unit) {
             title = stringResource(R.string.patch_debuggable)
         )
         SettingsCheckBox(
+            modifier = Modifier.clickable { viewModel.setGeoAPIKey = !viewModel.setGeoAPIKey },
+            checked = viewModel.setGeoAPIKey,
+            icon = Icons.Outlined.Public,
+            title = stringResource(R.string.patch_set_geo_api_key),
+            desc = stringResource(R.string.patch_set_geo_api_key_desc)
+        )
+        SettingsCheckBox(
             modifier = Modifier.clickable { viewModel.overrideVersionCode = !viewModel.overrideVersionCode },
             checked = viewModel.overrideVersionCode,
             icon = Icons.Outlined.Layers,

--- a/manager/src/main/java/org/lsposed/lspatch/ui/viewmodel/NewPatchViewModel.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/ui/viewmodel/NewPatchViewModel.kt
@@ -40,6 +40,7 @@ class NewPatchViewModel : ViewModel() {
     var sigBypassLevel by mutableStateOf(2)
     var injectDex by mutableStateOf(false)
     var embeddedModules = emptyList<AppInfo>()
+    var setGeoAPIKey by mutableStateOf(false)
 
     lateinit var patchApp: AppInfo
         private set
@@ -92,7 +93,7 @@ class NewPatchViewModel : ViewModel() {
         if (useManager) embeddedModules = emptyList()
         patchOptions = Patcher.Options(
             injectDex = injectDex,
-            config = PatchConfig(useManager, debuggable, overrideVersionCode, sigBypassLevel, null, null),
+            config = PatchConfig(useManager, debuggable, overrideVersionCode, sigBypassLevel, null, null, setGeoAPIKey),
             apkPaths = listOf(patchApp.app.sourceDir) + (patchApp.app.splitSourceDirs ?: emptyArray()),
             embeddedModules = embeddedModules.flatMap { listOf(it.app.sourceDir) + (it.app.splitSourceDirs ?: emptyArray()) }
         )

--- a/manager/src/main/res/values-ru/strings.xml
+++ b/manager/src/main/res/values-ru/strings.xml
@@ -88,4 +88,6 @@
     <string name="settings_detail_patch_logs">Подробности журнала патча</string>
     <string name="patch_inject_dex">Inject loader dex</string>
     <string name="patch_inject_dex_desc">Для приложений с изолированными сервисами, такими как рендеринг браузеров, пожалуйста, включите эту опцию, чтобы убедиться, что они работают должным образом.</string>
+    <string name="patch_set_geo_api_key">Установить GeoAPIKey</string>
+    <string name="patch_set_geo_api_key_desc">Должно помочь пропатченому приложению продолжить работать с Google Maps.</string>
 </resources>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -92,4 +92,6 @@
     <string name="settings_detail_patch_logs">Detail patch logs</string>
     <string name="patch_inject_dex">Inject loader dex</string>
     <string name="patch_inject_dex_desc">For applications with isolated services, such as the render engines of browsers, please turn on this option to ensure that they work properly.</string>
+    <string name="patch_set_geo_api_key">Set GeoAPIKey</string>
+    <string name="patch_set_geo_api_key_desc">Should help the patched application continue to work with the Google Maps.</string>
 </resources>

--- a/patch/src/main/java/org/lsposed/patch/LSPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/LSPatch.java
@@ -5,6 +5,7 @@ import static org.lsposed.lspatch.share.Constants.EMBEDDED_MODULES_ASSET_PATH;
 import static org.lsposed.lspatch.share.Constants.LOADER_DEX_ASSET_PATH;
 import static org.lsposed.lspatch.share.Constants.ORIGINAL_APK_ASSET_PATH;
 import static org.lsposed.lspatch.share.Constants.PROXY_APP_COMPONENT_FACTORY;
+import static org.lsposed.lspatch.share.Constants.GOOGLE_GEO_API_KEY;
 
 import com.android.tools.build.apkzlib.sign.SigningExtension;
 import com.android.tools.build.apkzlib.sign.SigningOptions;
@@ -96,6 +97,9 @@ public class LSPatch {
     @Parameter(names = {"-m", "--embed"}, description = "Embed provided modules to apk")
     private List<String> modules = new ArrayList<>();
 
+    @Parameter(names = {"-g", "--geoapi"}, description = "Set com.google.android.geo.API_KEY")
+    private boolean setGeoAPIKey = false;
+
     private static final String ANDROID_MANIFEST_XML = "AndroidManifest.xml";
     private static final HashSet<String> ARCHES = new HashSet<>(Arrays.asList(
             "armeabi-v7a",
@@ -157,9 +161,10 @@ public class LSPatch {
             outputDir.mkdirs();
 
             File outputFile = new File(outputDir, String.format(
-                    Locale.getDefault(), "%s-%d-lspatched.apk",
+                    Locale.getDefault(), "%s-%d%s-lspatched.apk",
                     FilenameUtils.getBaseName(apkFileName),
-                    LSPConfig.instance.VERSION_CODE)
+                    LSPConfig.instance.VERSION_CODE,
+                    setGeoAPIKey ? "-geo" : "")
             ).getAbsoluteFile();
 
             if (outputFile.exists() && !forceOverwrite)
@@ -250,7 +255,7 @@ public class LSPatch {
 
             logger.i("Patching apk...");
             // modify manifest
-            final var config = new PatchConfig(useManager, debuggableFlag, overrideVersionCode, sigbypassLevel, originalSignature, appComponentFactory);
+            final var config = new PatchConfig(useManager, debuggableFlag, overrideVersionCode, sigbypassLevel, originalSignature, appComponentFactory, setGeoAPIKey);
             final var configBytes = new Gson().toJson(config).getBytes(StandardCharsets.UTF_8);
             final var metadata = Base64.getEncoder().encodeToString(configBytes);
             try (var is = new ByteArrayInputStream(modifyManifestFile(manifestEntry.open(), metadata, minSdkVersion))) {
@@ -353,6 +358,10 @@ public class LSPatch {
             property.addUsesSdkAttribute(new AttributeItem(NodeValue.UsesSDK.MIN_SDK_VERSION, 28));
         property.addApplicationAttribute(new AttributeItem(NodeValue.Application.DEBUGGABLE, debuggableFlag));
         property.addApplicationAttribute(new AttributeItem("appComponentFactory", PROXY_APP_COMPONENT_FACTORY));
+        if (setGeoAPIKey) {
+            property.addMetaData(new ModificationProperty.MetaData("com.google.android.geo.API_KEY", GOOGLE_GEO_API_KEY));
+            logger.i("Set com.google.android.geo.API_KEY...");
+        }
         property.addMetaData(new ModificationProperty.MetaData("lspatch", metadata));
         // TODO: replace query_all with queries -> manager
         if (useManager)

--- a/share/java/src/main/java/org/lsposed/lspatch/share/Constants.java
+++ b/share/java/src/main/java/org/lsposed/lspatch/share/Constants.java
@@ -10,6 +10,7 @@ public class Constants {
 
     final static public String PATCH_FILE_SUFFIX = "-lspatched.apk";
     final static public String PROXY_APP_COMPONENT_FACTORY = "org.lsposed.lspatch.metaloader.LSPAppComponentFactoryStub";
+    final static public String GOOGLE_GEO_API_KEY = "AIzaSy*********************************";    // Here you will have to specify the desired value for the parameter com.google.android.geo.API_KEY
     final static public String MANAGER_PACKAGE_NAME = "org.lsposed.lspatch";
     final static public int MIN_ROLLING_VERSION_CODE = 348;
 

--- a/share/java/src/main/java/org/lsposed/lspatch/share/PatchConfig.java
+++ b/share/java/src/main/java/org/lsposed/lspatch/share/PatchConfig.java
@@ -8,6 +8,7 @@ public class PatchConfig {
     public final int sigBypassLevel;
     public final String originalSignature;
     public final String appComponentFactory;
+    public final boolean setGeoAPIKey;
     public final LSPConfig lspConfig;
 
     public PatchConfig(
@@ -16,7 +17,8 @@ public class PatchConfig {
             boolean overrideVersionCode,
             int sigBypassLevel,
             String originalSignature,
-            String appComponentFactory
+            String appComponentFactory,
+            boolean setGeoAPIKey
     ) {
         this.useManager = useManager;
         this.debuggable = debuggable;
@@ -24,6 +26,7 @@ public class PatchConfig {
         this.sigBypassLevel = sigBypassLevel;
         this.originalSignature = originalSignature;
         this.appComponentFactory = appComponentFactory;
+        this.setGeoAPIKey = setGeoAPIKey;
         this.lspConfig = LSPConfig.instance;
     }
 }


### PR DESCRIPTION
Added the ability to add a meta-data field to the _AndroidManifest.xml_ file with the _com.google.android.geo.API_KEY_ parameter and its value, which will need to be specified in the file _share/java/src/main/java/org/lsposed/lspatch/share/Constants.java_ before compiling LSPatch.

To do this, it will be enough to activate the corresponding item in the menu.
This will allow patched applications to work with Google Maps.
<img width="540" height="1077" alt="Screenshot_2026-05-24-21-24-37-965_org lsposed lspatch" src="https://github.com/user-attachments/assets/fb3dfe38-4fc7-458b-b40d-e1de54c35250" />
